### PR TITLE
Add assertions to code for commands classes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,4 +56,5 @@ shadowJar {
 
 run{
     standardInput = System.in
+    enableAssertions = true
 }

--- a/src/main/java/pie/command/AddDeadlineCommand.java
+++ b/src/main/java/pie/command/AddDeadlineCommand.java
@@ -20,11 +20,17 @@ public class AddDeadlineCommand extends Command {
      * @param deadline The {@link Deadline} task to be added.
      */
     public AddDeadlineCommand(Deadline deadline) {
+        assert deadline != null : "Deadline must not be null";
+
         this.deadline = deadline;
     }
 
     @Override
     public void execute(TaskList taskList, Ui ui, Storage storage) throws StorageException {
+        assert taskList != null : "TaskList must not be null when executing command";
+        assert ui != null : "Ui must not be null when executing command";
+        assert storage != null : "Storage must not be null when executing command";
+
         Task deadline = taskList.addDeadline(this.deadline);
         String outputMessage = MessageBuilder.taskAdded(deadline, taskList.getSize());
         ui.setMessage(outputMessage);

--- a/src/main/java/pie/command/AddEventCommand.java
+++ b/src/main/java/pie/command/AddEventCommand.java
@@ -20,11 +20,17 @@ public class AddEventCommand extends Command {
      * @param event The {@link Event} task to be added.
      */
     public AddEventCommand(Event event) {
+        assert event != null : "Event must not be null";
+
         this.event = event;
     }
 
     @Override
     public void execute(TaskList taskList, Ui ui, Storage storage) throws StorageException {
+        assert taskList != null : "TaskList must not be null when executing command";
+        assert ui != null : "Ui must not be null when executing command";
+        assert storage != null : "Storage must not be null when executing command";
+
         Task event = taskList.addEvent(this.event);
         String outputMessage = MessageBuilder.taskAdded(event, taskList.getSize());
         ui.setMessage(outputMessage);

--- a/src/main/java/pie/command/AddTodoCommand.java
+++ b/src/main/java/pie/command/AddTodoCommand.java
@@ -20,11 +20,18 @@ public class AddTodoCommand extends Command {
      * @param description Todo description.
      */
     public AddTodoCommand(String description) {
+        assert description != null : "Todo description must not be null";
+        assert !description.isBlank() : "Todo description must not be blank";
+
         this.description = description;
     }
 
     @Override
     public void execute(TaskList taskList, Ui ui, Storage storage) throws StorageException {
+        assert taskList != null : "TaskList must not be null when executing command";
+        assert ui != null : "Ui must not be null when executing command";
+        assert storage != null : "Storage must not be null when executing command";
+
         Task todo = taskList.addTodo(this.description);
         String outputMessage = MessageBuilder.taskAdded(todo, taskList.getSize());
         ui.setMessage(outputMessage);

--- a/src/main/java/pie/command/DeleteCommand.java
+++ b/src/main/java/pie/command/DeleteCommand.java
@@ -24,6 +24,10 @@ public class DeleteCommand extends Command {
 
     @Override
     public void execute(TaskList taskList, Ui ui, Storage storage) throws StorageException {
+        assert taskList != null : "TaskList must not be null when executing command";
+        assert ui != null : "Ui must not be null when executing command";
+        assert storage != null : "Storage must not be null when executing command";
+        
         Task task = taskList.deleteTask(index);
         String outputMessage = MessageBuilder.taskDeleted(task, taskList.getSize());
         ui.setMessage(outputMessage);

--- a/src/main/java/pie/command/ExitCommand.java
+++ b/src/main/java/pie/command/ExitCommand.java
@@ -11,6 +11,8 @@ import pie.ui.Ui;
 public class ExitCommand extends Command {
     @Override
     public void execute(TaskList taskList, Ui ui, Storage storage) {
+        assert ui != null : "Ui must not be null when executing command";
+
         ui.setMessage(MessageBuilder.bye());
     }
 

--- a/src/main/java/pie/command/FindCommand.java
+++ b/src/main/java/pie/command/FindCommand.java
@@ -20,11 +20,17 @@ public class FindCommand extends Command {
      * @param keyword The keyword to search for in task descriptions.
      */
     public FindCommand(String keyword) {
+        assert keyword != null : "Find keyword must not be null";
+        assert !keyword.isBlank() : "Find keyword must not be blank";
+
         this.keyword = keyword;
     }
 
     @Override
     public void execute(TaskList taskList, Ui ui, Storage storage) {
+        assert taskList != null : "TaskList must not be null when executing command";
+        assert ui != null : "Ui must not be null when executing command";
+
         List<Task> matchingTasks = taskList.findTasks(keyword);
         String outputMessage = MessageBuilder.matchingTasks(keyword, matchingTasks);
         ui.setMessage(outputMessage);

--- a/src/main/java/pie/command/ListCommand.java
+++ b/src/main/java/pie/command/ListCommand.java
@@ -13,6 +13,9 @@ public class ListCommand extends Command {
 
     @Override
     public void execute(TaskList taskList, Ui ui, Storage storage) throws StorageException {
+        assert taskList != null : "TaskList must not be null when executing command";
+        assert ui != null : "Ui must not be null when executing command";
+
         String outputMessage = MessageBuilder.taskList(taskList.getAllTasks());
         ui.setMessage(outputMessage);
     }

--- a/src/main/java/pie/command/MarkCommand.java
+++ b/src/main/java/pie/command/MarkCommand.java
@@ -24,6 +24,10 @@ public class MarkCommand extends Command {
 
     @Override
     public void execute(TaskList taskList, Ui ui, Storage storage) throws StorageException {
+        assert taskList != null : "TaskList must not be null when executing command";
+        assert ui != null : "Ui must not be null when executing command";
+        assert storage != null : "Storage must not be null when executing command";
+
         Task task = taskList.markTask(index);
         String outputMessage = MessageBuilder.taskMarked(task);
         ui.setMessage(outputMessage);

--- a/src/main/java/pie/command/OnCommand.java
+++ b/src/main/java/pie/command/OnCommand.java
@@ -21,11 +21,16 @@ public class OnCommand extends Command {
      * @param date The date to filter tasks by.
      */
     public OnCommand(LocalDate date) {
+        assert date != null : "Date must not be null";
+
         this.date = date;
     }
 
     @Override
     public void execute(TaskList taskList, Ui ui, Storage storage) {
+        assert taskList != null : "TaskList must not be null when executing command";
+        assert ui != null : "Ui must not be null when executing command";
+
         List<Task> result = taskList.getTasksOnDate(date);
         String outputMessage = MessageBuilder.tasksOnDate(date, result);
         ui.setMessage(outputMessage);

--- a/src/main/java/pie/command/UnmarkCommand.java
+++ b/src/main/java/pie/command/UnmarkCommand.java
@@ -24,6 +24,10 @@ public class UnmarkCommand extends Command {
 
     @Override
     public void execute(TaskList taskList, Ui ui, Storage storage) throws StorageException {
+        assert taskList != null : "TaskList must not be null when executing command";
+        assert ui != null : "Ui must not be null when executing command";
+        assert storage != null : "Storage must not be null when executing command";
+
         Task task = taskList.unmarkTask(index);
         String outputMessage = MessageBuilder.taskUnmarked(task);
         ui.setMessage(outputMessage);


### PR DESCRIPTION
This commit adds Java assert statements across core command classes to explicitly document important program invariants.

Assertions are used to state assumptions that must always hold in a correct execution, such as:
* Non-null command dependencies (TaskList, Ui, Storage)
* Valid task objects passed into command constructors

These assertions clarify developer intent and help catch programming errors early during development, without changing runtime behavior in production.